### PR TITLE
Added additional log based wait strategy

### DIFF
--- a/keycloak.go
+++ b/keycloak.go
@@ -92,12 +92,14 @@ func RunContainer(ctx context.Context, opts ...testcontainers.ContainerCustomize
 			contextPath = defaultKeycloakContextPath
 		}
 		if genericContainerReq.Env[keycloakTlsEnv] != "" {
-			genericContainerReq.WaitingFor = wait.ForHTTP(contextPath).
+			genericContainerReq.WaitingFor = wait.ForAll(wait.ForHTTP(contextPath).
 				WithPort(keycloakHttpsPort).
 				WithTLS(true).
-				WithAllowInsecure(true)
+				WithAllowInsecure(true),
+				wait.ForLog("Running the server"))
 		} else {
-			genericContainerReq.WaitingFor = wait.ForHTTP(contextPath)
+			genericContainerReq.WaitingFor = wait.ForAll(wait.ForHTTP(contextPath),
+				wait.ForLog("Running the server"))
 		}
 	}
 


### PR DESCRIPTION
Starting with Keycloak 24.0, initial imports of realm data from a json files seem to take longer. This can lead to tests starting before the imported realm is properly initialized and subsequent errors. The current ForHTTP strategy does not seem to ensure proper realm initialization. Therefore this PR proposes an additional wait strategy based on the final log line "Running the server" indicating the finalization of the startup process.